### PR TITLE
[FE-04] Add lead capture form and quotes API

### DIFF
--- a/frontend/src/api/quotes.ts
+++ b/frontend/src/api/quotes.ts
@@ -1,0 +1,99 @@
+import { API_BASE_URL } from './config'
+
+export interface QuoteSubmission {
+  name: string
+  email: string
+  address: string
+  monthly_bill: number
+}
+
+export interface QuoteResponse {
+  id: number
+  name: string
+  email: string
+  address: string
+  monthly_bill: string
+  estimated_savings: string
+  created_at: string
+}
+
+export interface ApiError {
+  error_code: string
+  message: string
+  field_errors?: Record<string, string[]>
+}
+
+const FRIENDLY_FIELD_MESSAGES: Record<string, Record<string, string>> = {
+  email: {
+    'Enter a valid email address.': 'Please enter a valid email address (e.g. jane@example.com).',
+    'This field is required.': 'We need your email so we can send you the quote.',
+  },
+  name: {
+    'This field is required.': 'Please enter your name.',
+  },
+  address: {
+    'This field is required.': 'Please enter your home address so we can assess your solar potential.',
+  },
+  monthly_bill: {
+    'This field is required.': 'Please enter your monthly electricity bill.',
+    'A valid number is required.': 'Please enter a number (e.g. 1500).',
+  },
+}
+
+function humanizeFieldErrors(fieldErrors: Record<string, string[]>): string[] {
+  const messages: string[] = []
+  for (const [field, errors] of Object.entries(fieldErrors)) {
+    for (const error of errors) {
+      const friendly = FRIENDLY_FIELD_MESSAGES[field]?.[error]
+      if (friendly) {
+        messages.push(friendly)
+      } else if (field === 'monthly_bill' && error.includes('greater than')) {
+        messages.push('Your monthly bill must be a positive number.')
+      } else {
+        const label = field.replace('_', ' ')
+        messages.push(`${label.charAt(0).toUpperCase() + label.slice(1)}: ${error}`)
+      }
+    }
+  }
+  return messages
+}
+
+export class QuoteApiError extends Error {
+  errorCode: string
+  friendlyMessages: string[]
+
+  constructor(apiError: ApiError) {
+    super(apiError.message)
+    this.errorCode = apiError.error_code
+    this.friendlyMessages = apiError.field_errors
+      ? humanizeFieldErrors(apiError.field_errors)
+      : [apiError.message]
+  }
+}
+
+export async function submitQuote(data: QuoteSubmission): Promise<QuoteResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/quotes/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    let apiError: ApiError
+    try {
+      apiError = await response.json()
+    } catch {
+      apiError = {
+        error_code: 'NETWORK_ERROR',
+        message: 'Could not connect to the server. Please try again.',
+      }
+    }
+    throw new QuoteApiError(apiError)
+  }
+  return response.json()
+}
+
+export async function fetchQuotes(): Promise<QuoteResponse[]> {
+  const response = await fetch(`${API_BASE_URL}/api/quotes/`)
+  if (!response.ok) throw new Error('Failed to fetch quotes')
+  return response.json()
+}

--- a/frontend/src/components/LeadCaptureForm.tsx
+++ b/frontend/src/components/LeadCaptureForm.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from 'react'
+import { submitQuote, QuoteApiError } from '../api/quotes'
+
+interface LeadCaptureFormProps {
+  initialBill?: number
+}
+
+type Status = 'idle' | 'loading' | 'success' | 'error'
+
+export default function LeadCaptureForm({ initialBill = 0 }: LeadCaptureFormProps) {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [address, setAddress] = useState('')
+  const [bill, setBill] = useState(initialBill)
+  const [status, setStatus] = useState<Status>('idle')
+  const [errorMessages, setErrorMessages] = useState<string[]>([])
+
+  useEffect(() => {
+    setBill(initialBill)
+  }, [initialBill])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus('loading')
+    setErrorMessages([])
+
+    try {
+      await submitQuote({ name, email, address, monthly_bill: bill })
+      setStatus('success')
+      setName('')
+      setEmail('')
+      setAddress('')
+      setBill(0)
+    } catch (err) {
+      setStatus('error')
+      if (err instanceof QuoteApiError) {
+        setErrorMessages(err.friendlyMessages)
+      } else {
+        setErrorMessages(['Something went wrong. Please check your connection and try again.'])
+      }
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="bg-green-50 border border-green-200 rounded-xl p-8 text-center">
+        <div className="text-4xl mb-3">✅</div>
+        <h3 className="text-lg font-semibold text-green-800">Quote request sent!</h3>
+        <p className="text-green-600 text-sm mt-1">We'll be in touch with your personalized quote shortly.</p>
+        <button
+          onClick={() => setStatus('idle')}
+          className="mt-4 text-sm text-green-700 underline"
+        >
+          Submit another request
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+      <h2 className="text-xl font-semibold text-gray-900 mb-1">Request your personalized quote</h2>
+      <p className="text-gray-500 text-sm mb-5">
+        Fill in your details and we'll get back to you with a tailored offer.
+      </p>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Full name</label>
+          <input
+            type="text"
+            required
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Jane Smith"
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber-400"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Email address</label>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="jane@example.com"
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber-400"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Home address</label>
+          <textarea
+            required
+            value={address}
+            onChange={e => setAddress(e.target.value)}
+            placeholder="1 Solar Street, Stockholm"
+            rows={2}
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber-400 resize-none"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Monthly electricity bill (SEK)
+          </label>
+          <input
+            type="number"
+            required
+            min={1}
+            value={bill || ''}
+            onChange={e => setBill(parseFloat(e.target.value) || 0)}
+            placeholder="e.g. 1500"
+            className="w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:outline-none focus:ring-2 focus:ring-amber-400"
+          />
+        </div>
+
+        {errorMessages.length > 0 && (
+          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3"
+               role="alert">
+            {errorMessages.length === 1 ? (
+              <p>{errorMessages[0]}</p>
+            ) : (
+              <ul className="list-disc list-inside space-y-1">
+                {errorMessages.map((msg, i) => <li key={i}>{msg}</li>)}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={status === 'loading'}
+          className="bg-amber-500 hover:bg-amber-600 disabled:bg-amber-300 text-white font-semibold
+                     rounded-lg px-6 py-3 transition-colors"
+        >
+          {status === 'loading' ? 'Sending...' : 'Get my quote →'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/QuoteFormPage.tsx
+++ b/frontend/src/pages/QuoteFormPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import SavingsCalculator from '../components/SavingsCalculator'
+import LeadCaptureForm from '../components/LeadCaptureForm'
 
 export default function QuoteFormPage() {
-  const [_monthlyBill, setMonthlyBill] = useState(0)
+  const [monthlyBill, setMonthlyBill] = useState(0)
 
   return (
     <div className="flex flex-col gap-6">
@@ -11,7 +12,7 @@ export default function QuoteFormPage() {
         <p className="text-gray-500 mt-1">Find out how much you could save by switching to solar.</p>
       </div>
       <SavingsCalculator onBillChange={setMonthlyBill} />
-      {/* Lead Capture Form will go here in FE-04 */}
+      <LeadCaptureForm initialBill={monthlyBill} />
     </div>
   )
 }


### PR DESCRIPTION
This pull request introduces a new lead capture form for requesting personalized quotes and integrates it into the quote form page. The main changes include implementing the form component with validation and error handling, adding API logic for submitting and fetching quotes, and updating the quote page to use the new form.

**Lead Capture Form Implementation:**
- Added a new `LeadCaptureForm` React component that allows users to submit their name, email, address, and monthly bill to request a personalized quote. The form includes client-side validation, displays friendly error messages, and shows a success message on submission.

**API Integration and Error Handling:**
- Created a new API module (`quotes.ts`) with functions for submitting and fetching quotes. This includes robust error handling, friendly error message mapping, and a custom `QuoteApiError` class for surfacing user-friendly errors to the UI.

**Page Integration:**
- Updated the `QuoteFormPage` to render the new `LeadCaptureForm`, passing the current monthly bill from the savings calculator as the initial value.

Closes #10 